### PR TITLE
Fix: Correct scope declaration for boss variables in reset_game_state

### DIFF
--- a/main.py
+++ b/main.py
@@ -194,8 +194,9 @@ def main():
 
     def reset_game_state():
         nonlocal game_start_time, player, enemies, items, all_player_bullets, all_enemy_bullets
-        nonlocal reisen_instance, reisen_defeated_effect_timer
-        nonlocal kaguya_instance, kaguya_spawn_timer, kaguya_defeat_effect_timer
+        # These are module-level globals, modified within main() and reset here.
+        global reisen_instance, reisen_defeated_effect_timer
+        global kaguya_instance, kaguya_spawn_timer, kaguya_defeat_effect_timer, kaguya_was_spawned_flag
         
         game_start_time = 0 
         player = Player(asset_manager) # Pass asset_manager


### PR DESCRIPTION
I resolved a SyntaxError in `main.py` caused by incorrect use of `nonlocal` for global boss state variables (`reisen_instance`, `kaguya_instance`, etc.) within the nested `reset_game_state` function.

I changed the declarations for these global variables from `nonlocal` to `global` inside `reset_game_state` to correctly refer to and modify the module-level variables. Other variables that are truly local to the `main()` function's scope retain their `nonlocal` declarations within `reset_game_state`.

This change should fix the startup crash and ensure that your game state, particularly relating to boss instances and timers, is correctly reset when starting a new game.